### PR TITLE
Add Labels with the image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,13 @@
 FROM gliderlabs/alpine:latest
 
 LABEL maintainer="elastest-users@googlegroups.com"
-LABEL version="0.1.0"
 LABEL description="Builds the service manager docker image."
+ARG GIT_COMMIT=unspecified
+LABEL git_commit=$GIT_COMMIT
+ARG COMMIT_DATE=unspecified
+LABEL commit_date=$COMMIT_DATE
+ARG VERSION=unspecified
+LABEL version=$VERSION
 
 WORKDIR /app
 COPY ./src /app

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,8 +69,7 @@ node('docker'){
 
             stage "Build image - Package"
                 echo ("building...")
-                sh 'docker build --build-arg GIT_COMMIT=$(git rev-parse HEAD) --build-arg COMMIT_DATE=$(git log -1 --format=%cd --date=format:%Y-%m-%dT%H:%M:%S) 
-                . -t elastest/esm:latest'
+                sh 'docker build --build-arg GIT_COMMIT=$(git rev-parse HEAD) --build-arg COMMIT_DATE=$(git log -1 --format=%cd --date=format:%Y-%m-%dT%H:%M:%S) . -t elastest/esm:latest'
                 def myimage = docker.image("elastest/esm:latest")
 
             stage "Publish"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,7 +69,8 @@ node('docker'){
 
             stage "Build image - Package"
                 echo ("building...")
-                def myimage = docker.build("elastest/esm:latest")
+                sh 'docker build --build-arg GIT_COMMIT=$(git rev-parse HEAD) --build-arg COMMIT_DATE=$(git log -1 --format=%cd --date=format:%Y-%m-%dT%H:%M:%S) -f eus/Dockerfile . -t elastest/esm:latest'
+                def myimage = docker.image("elastest/esm:latest")
 
             stage "Publish"
                 echo ("Publishing as all tests succeeded...")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,7 +69,8 @@ node('docker'){
 
             stage "Build image - Package"
                 echo ("building...")
-                sh 'docker build --build-arg GIT_COMMIT=$(git rev-parse HEAD) --build-arg COMMIT_DATE=$(git log -1 --format=%cd --date=format:%Y-%m-%dT%H:%M:%S) -f eus/Dockerfile . -t elastest/esm:latest'
+                sh 'docker build --build-arg GIT_COMMIT=$(git rev-parse HEAD) --build-arg COMMIT_DATE=$(git log -1 --format=%cd --date=format:%Y-%m-%dT%H:%M:%S) 
+                . -t elastest/esm:latest'
                 def myimage = docker.image("elastest/esm:latest")
 
             stage "Publish"


### PR DESCRIPTION
- This information will be displayed in the ETM GUI
- We need to show the following fields:
      1. Commit id
      2. Commit date
      3. Version (the release name). Today is not defined how / when it will be established

